### PR TITLE
*: make config groups optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ files of the same name in `/usr/lib/fedora-coreos-metrics-client/config.d/`.
 Config files are read in alphanumeric order; config files ordered later
 override config files ordered earlier.
 
-By default, metrics reporting is enabled, and the level of information
-collected is set to `minimal`. An example of the default config is as follows:
+The metrics reporting `enabled` flag must be explicitly set by a config file.
+If not specified, the service will exit with error. If metrics reporting is
+enabled, then by default the level of information collected is set to
+`"minimal"`. An example of the default config is as follows:
 
 ```TOML
 # /usr/lib/fedora-coreos-metrics-client/config.d/0000-client-default.toml
@@ -48,7 +50,7 @@ collected is set to `minimal`. An example of the default config is as follows:
 level = "minimal"
 
 [reporting]
-# Default reporting.enabled is `true`. May be set to `true` or `false`.
+# Required. May be set to `true` or `false`.
 enabled = true
 
 ```
@@ -58,9 +60,6 @@ dropped at e.g.
 `/etc/fedora-coreos-metrics-client/config.d/9000-client-disable-reporting.toml`.
 
 ```TOML
-[collecting]
-level = "minimal"
-
 [reporting]
 enabled = false
 

--- a/dist/0000-client-default.toml
+++ b/dist/0000-client-default.toml
@@ -5,5 +5,5 @@
 level = "minimal"
 
 [reporting]
-# Default reporting.enabled is `true`. May be set to `true` or `false`.
+# Required. May be set to `true` or `false`.
 enabled = true

--- a/src/config/fragments.rs
+++ b/src/config/fragments.rs
@@ -5,22 +5,22 @@ use serde::Deserialize;
 /// Metrics client config.
 #[derive(Debug, Deserialize, PartialEq)]
 pub(crate) struct ConfigFragment {
-    pub(crate) collecting: CollectingFragment,
-    pub(crate) reporting: ReportingFragment,
+    pub(crate) collecting: Option<CollectingFragment>,
+    pub(crate) reporting: Option<ReportingFragment>,
 }
 
 /// Collecting config group.
 #[derive(Debug, Deserialize, PartialEq)]
 pub(crate) struct CollectingFragment {
-    /// Metrics collection level, may be `"minimal"` or `"full"` (required).
-    pub(crate) level: String,
+    /// Metrics collection level, may be `"minimal"` or `"full"` (default: "minimal").
+    pub(crate) level: Option<String>,
 }
 
 /// Reporting config group.
 #[derive(Debug, Deserialize, PartialEq)]
 pub(crate) struct ReportingFragment {
     /// Metrics reporting enablement flag (required).
-    pub(crate) enabled: bool,
+    pub(crate) enabled: Option<bool>,
 }
 
 #[cfg(test)]
@@ -37,12 +37,12 @@ mod tests {
         let cfg: ConfigFragment = toml::from_slice(&content).unwrap();
 
         let expected = ConfigFragment {
-            collecting: CollectingFragment {
-                level: String::from("minimal")
-            },
-            reporting: ReportingFragment {
-                enabled: true,
-            },
+            collecting: Some(CollectingFragment {
+                level: Some("minimal".to_string()),
+            }),
+            reporting: Some(ReportingFragment {
+                enabled: Some(true),
+            }),
         };
 
         assert_eq!(cfg, expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,7 @@ use std::path;
 /// and check that the keys are set to a valid telemetry setting. If not,
 /// or in case of other error, return non-zero.
 fn check_metrics_config(config: inputs::ConfigInput) -> failure::Fallible<()> {
-    let reporting_enabled = config.reporting.enabled;
-    if reporting_enabled {
+    if config.reporting.enabled.unwrap() {
         info!("Metrics reporting enabled.");
 
         let collecting_level = config.collecting.level;


### PR DESCRIPTION
Previously, both the `reporting` and `collecting` groups had to
be specified in every config snippet in order for the TOML
parsing to succeed. Instead make the groups and their keys
optional, and later perform validation for keys that are
required (such as `reporting.enabled`) once all the snippets
have been parsed.

This implicitly makes the default `collecting.level` value
`"minimal"`, which only takes effect if metrics reporting is
enabled.