### PR TITLE
revert "use liboverdrop crate"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "Apache-2.0"
 clap = "2.33"
 env_logger = "^0.6.1"
 failure = "^0.1.5"
-liboverdrop = { git = "https://github.com/overdrop/liboverdrop-rs", branch = "master" }
 log = "^0.4.6"
 serde = { version = "^1.0.91", features = ["derive"] }
 toml = "^0.5.1"

--- a/src/config/inputs.rs
+++ b/src/config/inputs.rs
@@ -4,8 +4,32 @@
 use crate::config::fragments;
 
 use failure::{bail, ResultExt};
+use log::debug;
 use serde::Serialize;
-use std::{collections, path};
+use std::{collections, fs, path};
+
+/// Read dir and add file (name, path) keys to tree.
+fn add_snippets_to_tree(
+    dir: &path::PathBuf,
+    tree: &mut collections::BTreeMap<String, path::PathBuf>
+) -> failure::Fallible<()> {
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            debug!("found fragment '{}'", path.display());
+
+            if !path.is_dir() && path.extension().unwrap() == "toml" {
+                let key = path.file_name().unwrap().to_str().unwrap().to_owned();
+                if !tree.contains_key(&key) {
+                    debug!("adding fragment with filename '{}' to config", key);
+                    tree.insert(key, path);
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 #[derive(Debug, Serialize)]
 pub(crate) struct ConfigInput {
@@ -16,16 +40,16 @@ pub(crate) struct ConfigInput {
 impl ConfigInput {
     /// Read config fragments and merge them into a single config.
     pub(crate) fn read_configs(
-        dirs: Vec<String>,
+        dirs: &[path::PathBuf],
         app_name: &str
     ) -> failure::Fallible<Self> {
-        let config_path = format!("{}/config.d", app_name);
-        let allowed_extensions = vec![
-            String::from("toml"),
-        ];
-        let od_cfg = liboverdrop::FragmentScanner::new(dirs, config_path.as_str(), false, allowed_extensions);
+        let mut fragments = collections::BTreeMap::new();
+        for prefix in dirs {
+            let dir = path::PathBuf::from(format!("{}/{}/config.d", prefix.as_path().display(), app_name));
+            debug!("scanning configuration directory '{}'", dir.display());
 
-        let fragments = od_cfg.scan();
+            add_snippets_to_tree(&dir, &mut fragments)?;
+        }
 
         let cfg = Self::merge_fragments(fragments)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use clap::{Arg, crate_authors, crate_description, crate_name, crate_version};
 use config::inputs;
 use failure::{bail, ResultExt};
 use log::LevelFilter;
+use path::PathBuf;
+use std::path;
 
 /// Parse the reporting.enabled and collecting.level keys from config fragments,
 /// and check that the keys are set to a valid telemetry setting. If not,
@@ -45,11 +47,11 @@ fn main() -> failure::Fallible<()> {
         .try_init()?;
 
     let dirs = vec![
-        String::from("/usr/lib"),
-        String::from("/run"),
-        String::from("/etc"),
+        PathBuf::from("/etc"),
+        PathBuf::from("/run"),
+        PathBuf::from("/usr/lib"),
     ];
-    let config = inputs::ConfigInput::read_configs(dirs, crate_name!())
+    let config = inputs::ConfigInput::read_configs(&dirs, crate_name!())
         .context("failed to read configuration input")?;
 
     check_metrics_config(config)?;


### PR DESCRIPTION
Revert an accidental push to master (commit: 63f903631d3a68cf0ac70fcdfbff1b69a51f55aa).