### PR TITLE
cargo: drop deprecated badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ exclude = [
 ".travis.yml",
 ]
 
-[badges]
-maintenance = { status = "deprecated" }
-
 [dependencies]
 clap = "2.33"
 env_logger = "^0.6.1"


### PR DESCRIPTION
Left over from #17 - will include this change in the next release.