### PR TITLE
Release 0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedora-coreos-pinger"
-version = "0.0.4"
+version = "0.0.5-alpha.0"
 authors = ["Robert Fairley <rfairley@redhat.com>"]
 edition = "2018"
 description = "Telemetry service for Fedora CoreOS"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedora-coreos-pinger"
-version = "0.0.4-alpha.0"
+version = "0.0.4"
 authors = ["Robert Fairley <rfairley@redhat.com>"]
 edition = "2018"
 description = "Telemetry service for Fedora CoreOS"


### PR DESCRIPTION
A couple of minor cleanups went in since 0.0.3, let's release a new version with these in, and have the `0.0.4` ready for a package review in Fedora (for #3).