### PR TITLE
dist: rename user and group to fcos-pinger

### DIFF
--- a/dist/systemd/fedora-coreos-pinger.service
+++ b/dist/systemd/fedora-coreos-pinger.service
@@ -6,8 +6,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=fedora-coreos-pinger
-Group=fedora-coreos-pinger
+User=fcos-pinger
+Group=fcos-pinger
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/fedora-coreos-pinger

--- a/dist/sysusers.d/50-fedora-coreos-pinger.conf
+++ b/dist/sysusers.d/50-fedora-coreos-pinger.conf
@@ -1,3 +1,3 @@
-#fedora-coreos-pinger - https://github.com/coreos/fedora-coreos-pinger
-#Type  Name                          ID  GECOS
-u      fedora-coreos-pinger  -   "Fedora CoreOS telemetry service user"
+#Fedora CoreOS pinger - https://github.com/coreos/fedora-coreos-pinger
+#Type  Name         ID  GECOS
+u      fcos-pinger  -   "Fedora CoreOS pinger service user"

--- a/dist/tmpfiles.d/fedora-coreos-pinger.conf
+++ b/dist/tmpfiles.d/fedora-coreos-pinger.conf
@@ -1,3 +1,3 @@
 # Runtime configuration fragments - https://github.com/coreos/fedora-coreos-pinger
-#Type Path                               Mode User                 Group                Age Argument
-d     /run/fedora-coreos-pinger/config.d 0775 fedora-coreos-pinger fedora-coreos-pinger -   -
+#Type Path                               Mode User        Group       Age Argument
+d     /run/fedora-coreos-pinger/config.d 0775 fcos-pinger fcos-pinger -   -


### PR DESCRIPTION
Rename the sysuser and group `fedora-coreos-pinger` to
`fcos-pinger` which is a saner character length. This is
neater particularly when displayed in directory listings.
`fcos-` in the name prefix, along with the GECOS, should
still make it clear where the user comes from.

Fixes: https://github.com/coreos/fedora-coreos-pinger/issues/21