### PR TITLE
dist/systemd: change binary location to /usr/libexec

### DIFF
--- a/dist/systemd/fedora-coreos-pinger.service
+++ b/dist/systemd/fedora-coreos-pinger.service
@@ -10,7 +10,7 @@ User=fcos-pinger
 Group=fcos-pinger
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/fedora-coreos-pinger
+ExecStart=/usr/libexec/fedora-coreos-pinger
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Change the directory of the installed binary from /usr/bin to
/usr/libexec. This is done because `fedora-coreos-pinger` is not
intended to be run directly by users.

When installing and running pinger through this unit, the binary
placed by cargo install should be moved to this location under
/usr/libexec.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/244