### PR TITLE
Use DynamicUser=yes

### DIFF
--- a/dist/systemd/fedora-coreos-pinger.service
+++ b/dist/systemd/fedora-coreos-pinger.service
@@ -6,8 +6,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=fcos-pinger
-Group=fcos-pinger
+DynamicUser=yes
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/libexec/fedora-coreos-pinger

--- a/dist/sysusers.d/50-fedora-coreos-pinger.conf
+++ b/dist/sysusers.d/50-fedora-coreos-pinger.conf
@@ -1,3 +1,0 @@
-#Fedora CoreOS pinger - https://github.com/coreos/fedora-coreos-pinger
-#Type  Name         ID  GECOS
-u      fcos-pinger  -   "Fedora CoreOS pinger service user"

--- a/dist/tmpfiles.d/fedora-coreos-pinger.conf
+++ b/dist/tmpfiles.d/fedora-coreos-pinger.conf
@@ -1,3 +1,0 @@
-# Runtime configuration fragments - https://github.com/coreos/fedora-coreos-pinger
-#Type Path                               Mode User        Group       Age Argument
-d     /run/fedora-coreos-pinger/config.d 0775 fcos-pinger fcos-pinger -   -


### PR DESCRIPTION
I was looking at `/etc/passwd` on FCOS and noticed a user allocated
for this service.

With modern systemd, I think `DynamicUser=yes` is exactly what
we want for this type of service.  We don't need to allocate
a uid/gid persistently on the system.  It's just a lot cleaner
this way.

Drop the `tmpfiles.d` snippet too; this means the admin would need
to `mkdir` that directory.  Which is probably better actually,
because we don't want the directory to actually be *owned* by the
service user since then it'd be mutable by the service.  The
admin just needs to make the directories world executable and
the files world-readable.