### PR TITLE
systemd: add persistent state and report with different intervals

### DIFF
--- a/dist/systemd/fedora-coreos-pinger.service
+++ b/dist/systemd/fedora-coreos-pinger.service
@@ -9,6 +9,7 @@ After=network-online.target
 DynamicUser=yes
 Type=oneshot
 RemainAfterExit=yes
+StateDirectory=fedora-coreos-pinger
 ExecStart=/usr/libexec/fedora-coreos-pinger
 
 [Install]


### PR DESCRIPTION
Add `StateDirecory=fedora-coreos-pinger` to the systemd file and store different timestamps in the persistent files under `/var/lib/fedora-coreos-pinger`, for example (`timestamp_daily` and `timestamp_monthly`). Report when intervals between timestamps are more than one day or one month.

Signed-off-by: Allen Bai <abai@redhat.com>