### PR TITLE
Bump env_logger to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 clap = "2.33"
-env_logger = "^0.6.1"
+env_logger = "^0.7.1"
 failure = "^0.1.5"
 liboverdrop = "^0.0.2"
 log = "^0.4.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,8 @@ fn main() -> failure::Fallible<()> {
         3 | _ => LevelFilter::Trace,
     };
     env_logger::Builder::from_default_env()
-        .default_format_timestamp(false)
-        .default_format_module_path(false)
+        .format_timestamp(None)
+        .format_module_path(false)
         .filter(None, log_level)
         .try_init()?;
 


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Hey Robert,

Following your update of env_logger in Fedora I thought you might want to update it here too, there's just a slight API change.