### PR TITLE
service: drop requirement on network-online.target

### DIFF
--- a/dist/systemd/fedora-coreos-pinger.service
+++ b/dist/systemd/fedora-coreos-pinger.service
@@ -2,8 +2,6 @@
 Description=Telemetry service for Fedora CoreOS
 Documentation=https://github.com/coreos/fedora-coreos-pinger
 Before=systemd-user-sessions.service
-Wants=network-online.target
-After=network-online.target
 
 [Service]
 DynamicUser=yes


### PR DESCRIPTION
As per systemd recommendations[1], we should avoid depending on this
unit. Instead, if/when we do implement the reporting bits, we should be
resilient to networks taking time to come online or temporary network
flakes.

This is the only thing which is actively pulling in
`network-online.target` right now (the other one being `docker.service`,
but we have less control over that one, and it's disabled by default).

[1] https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/