### PR TITLE
cargo: explicitly set `sign-tag`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ toml = "^0.5.1"
 
 [package.metadata.release]
 sign-commit = true
+sign-tag = true
 upload-doc = false
 disable-push = true
 disable-publish = true


### PR DESCRIPTION
Quiet cargo-release warning.